### PR TITLE
Improve checkout responsive menu

### DIFF
--- a/public/checkout.html
+++ b/public/checkout.html
@@ -124,6 +124,26 @@
     </div>
   </div>
 
+  <!-- Bottom Navigation (mobile only) -->
+  <nav class="bottom-nav">
+    <a href="/meus-cupons" class="nav-item">
+      <span class="nav-icon icon-ticket"></span>
+      <span class="nav-label">Meus títulos</span>
+    </a>
+    <a href="/comprar" class="nav-item active">
+      <span class="nav-icon icon-dollar"></span>
+      <span class="nav-label">Comprar</span>
+    </a>
+    <a href="/resultados" class="nav-item">
+      <span class="nav-icon icon-trophy"></span>
+      <span class="nav-label">Resultados</span>
+    </a>
+    <a href="/consulta" class="nav-item">
+      <span class="nav-icon icon-search"></span>
+      <span class="nav-label">Consulta</span>
+    </a>
+  </nav>
+
   <!-- ====== Footer ====== -->
   <footer class="site-footer">
     <div class="footer-top">

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -724,9 +724,11 @@ img {
   bottom: 0;
   left: 0;
   right: 0;
-  display: flex;
+  display: none;
+  justify-content: space-around;
   background: var(--color-neutral-white);
   border-top: 1px solid var(--color-neutral-200);
+  z-index: 1000;
 }
 .nav-item {
   flex: 1;
@@ -734,6 +736,7 @@ img {
   padding: 0.5rem 0;
   color: var(--color-neutral-500);
   font-size: 0.875rem;
+  text-decoration: none;
 }
 .nav-item.active {
   color: var(--color-brand-primary-500);
@@ -757,4 +760,28 @@ img {
   content: "\f091";
   font-family: "Font Awesome 6 Free";
   font-weight: 900;
+}
+.icon-search::before {
+  content: "\f002";
+  font-family: "Font Awesome 6 Free";
+  font-weight: 900;
+}
+
+@media (max-width: 768px) {
+  .bottom-nav {
+    display: flex;
+    animation: fadeIn 0.5s ease-in-out;
+  }
+}
+
+@media (min-width: 769px) {
+  .bottom-nav {
+    display: none;
+  }
+}
+
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }


### PR DESCRIPTION
## Summary
- add bottom navigation from Consulta page to `checkout.html`
- hide bottom navigation on desktop with media queries
- include new Consulta link with search icon for mobile menu

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68767a26df008325b12fb20f5dc0e69e