### PR TITLE
Adjust checkout flow

### DIFF
--- a/public/checkout.html
+++ b/public/checkout.html
@@ -110,7 +110,7 @@
       </section>
       <!-- === COLUNA DA DIREITA: QR / PIX === -->
       <section class="qr-panel">
-        <div class="qr-placeholder">
+        <div class="qr-placeholder" id="qrPlaceholder">
           <div class="icon-qr"></div>
           <p>Preencha as informações ao lado para gerar o QR code</p>
         </div>


### PR DESCRIPTION
## Summary
- generate PIX payment before registering atendimento
- poll for payment status and register atendimento once paid
- tweak checkout page to display generated QR code

## Testing
- `node --check server.js`
- `node --check public/js/checkout.js`
- `node server.js & sleep 2; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_687863e85894832594c79f32c5665711