### PR TITLE
Add fallback coupon retrieval on consulta

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1034,3 +1034,5 @@ img {
 }
 .coupon-qrcode { margin-top: 0.5rem; max-width: 150px; display: none; }
 #pagination { display:flex; gap:1rem; justify-content:center; margin-top:1rem; }
+.dozens-table { width:100%; border-collapse:collapse; margin-top:0.5rem; }
+.dozens-table td { border:1px solid #ddd; padding:0.25rem; text-align:center; }


### PR DESCRIPTION
## Summary
- add fallback API logic to `/api/user` that retrieves coupons if user lookup fails
- enhance consulta page JS to use fallback data, sort coupons, and display numbers
- style dozens table for coupon numbers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687958c6fb108325ade3e5cd0e6346f4