### PR TITLE
Refine coupon results display

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1018,27 +1018,7 @@ img {
   margin-bottom: 2rem;
 }
 .product-list label { display: block; margin-bottom: .5rem; color: #333; }
-.coupon-card {
-  background: var(--color-neutral-white);
-  color: var(--color-neutral-black);
-  border-radius: var(--radius);
-  padding: 1rem;
-  margin-bottom: 1rem;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-}
-.coupon-card button {
-  margin-top: 0.5rem;
-  background: var(--color-brand-primary-500);
-  color: var(--color-neutral-white);
-  border: none;
-  border-radius: var(--radius);
-  padding: 0.5rem 1rem;
-  cursor: pointer;
-}
-.coupon-qrcode { margin-top: 0.5rem; max-width: 150px; display: none; }
 #pagination { display:flex; gap:1rem; justify-content:center; margin-top:1rem; }
-.dozens-table { width:100%; border-collapse:collapse; margin-top:0.5rem; }
-.dozens-table td { border:1px solid #ddd; padding:0.25rem; text-align:center; }
 /* ——— Consulta: product row styling ——————————————————— */
 .product-item {
   display: block;
@@ -1080,70 +1060,46 @@ img {
 
 /* ==== Consulta – resultados em estilo “HiperCap” ==== */
 .coupon-card {
-  background: var(--color-neutral-white);
-  color: var(--color-neutral-black);
-  border: 2px solid var(--color-support-yellow-500);
-  border-radius: var(--radius);
-  padding: 1rem;
-  margin-bottom: 1.5rem;
-  position: relative;
-  overflow: hidden;
-}
-
-/* header: duas colunas – data/horário e título/prêmio */
-.coupon-header {
-  display: grid;
-  grid-template-columns: 1fr 2fr;
-  gap: var(--gap);
-}
-
-.info-block {
-  background: #f9f9f9;
-  padding: 0.5rem;
-  border-radius: var(--radius);
-}
-.info-block .label {
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--color-neutral-500);
-  margin-bottom: 0.25rem;
-}
-.info-block p {
-  margin: 0 0 0.5rem;
-  font-size: 0.875rem;
-}
-
-/* status “Encerrado” */
-.status-badge {
-  position: absolute;
-  top: 1rem;
-  left: 50%;
-  transform: translateX(-50%);
-  background: var(--color-neutral-500);
+  display: flex;
+  align-items: stretch;
+  background: var(--color-brand-primary-700);
   color: var(--color-neutral-white);
-  padding: 0.25rem 0.75rem;
   border-radius: var(--radius);
-  font-size: 0.75rem;
+  overflow: hidden;
+  margin-bottom: 1rem;
 }
 
-/* expand button */
-.btn-expand {
-  display: block;
-  width: 100%;
-  background: var(--color-support-yellow-500);
-  color: var(--color-neutral-black);
-  border: none;
-  border-radius: var(--radius);
+.coupon-img img {
+  width: 80px;
+  height: 100%;
+  object-fit: cover;
+}
+
+.coupon-details {
+  flex: 1;
   padding: 0.75rem;
-  font-weight: bold;
-  cursor: pointer;
-  margin-top: var(--gap);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 
-/* area que abre/fecha */
-.expand-section {
-  display: none;
-  margin-top: var(--gap);
+.coupon-head {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.coupon-head p {
+  margin: 0;
+}
+
+.title-number p:last-child {
+  font-weight: 700;
+}
+
+.auth {
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
 }
 .results-section {
   display: flex;
@@ -1154,6 +1110,14 @@ img {
   border-radius: var(--radius);
   padding: var(--gap);
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+@media (max-width: var(--bs-md)) {
+  .results-section {
+    margin: 0;
+    padding-left: 0;
+    padding-right: 0;
+  }
 }
 .results {
   width: fit-content;
@@ -1179,13 +1143,16 @@ img {
 .dezenas-table {
   width: 100%;
   border-collapse: collapse;
+  table-layout: fixed;
 }
 .dezenas-table th,
 .dezenas-table td {
-  border: 1px solid #ddd;
-  padding: 0.5rem;
+  border: 1px solid var(--color-neutral-white);
+  padding: 0.25rem;
   text-align: center;
   font-size: 0.875rem;
+  width: 20%;
+  aspect-ratio: 1;
 }
 .dezenas-table th {
   background: #f1f1f1;

--- a/public/js/consulta.js
+++ b/public/js/consulta.js
@@ -173,84 +173,58 @@ function displayResults(data) {
   resultsEl.innerHTML = '';
 
   Object.entries(data).forEach(([produto, cupons]) => {
-    // título do produto
     const productTitle = document.createElement('h3');
     productTitle.textContent = produto;
     productTitle.style.textAlign = 'left';
     productTitle.style.margin = '1rem 0';
     resultsEl.appendChild(productTitle);
 
-    // para cada cupom
     cupons
       .sort((a, b) => parseDate(b.dataCupom) - parseDate(a.dataCupom))
       .forEach(c => {
-        const card = document.createElement('div');
-        card.className = 'coupon-card';
+        const banner = (c.promocao && c.promocao.banner) || c.imagemPremio || '';
+        const chances = Array.isArray(c.numeroSorte) && c.numeroSorte.length
+          ? c.numeroSorte
+          : [{ dezenas: c.dezenas || [], numero: '' }];
 
-        // estrutura principal do card
-        card.innerHTML = `
-          <div class="coupon-header">
-            <div class="info-block">
-              <div class="label">Data</div>
-              <div>${c.dataCupom.split(' ')[0]}</div>
-              <div class="label">Horário</div>
-              <div>${c.dataCupom.split(' ')[1] || ''}</div>
+        chances.forEach((chanceObj, idx) => {
+          const dezenas = chanceObj.dezenas || [];
+
+          const card = document.createElement('div');
+          card.className = 'coupon-card';
+
+          card.innerHTML = `
+            <div class="coupon-img">${
+              banner ? `<img src="${banner}" alt="ilustração promoção" />` : ''
+            }</div>
+            <div class="coupon-details">
+              <div class="coupon-head">
+                <p class="chance-label">Chance (${idx + 1})</p>
+                <div class="title-number">
+                  <p>Nº do Título</p>
+                  <p>${c.idTituloPromocao}</p>
+                </div>
+              </div>
+              <table class="dezenas-table"></table>
+              <div class="auth">Autenticação: ${c.autenticacao || ''}</div>
             </div>
-            <div class="info-block">
-              <div class="label">Nº do Título</div>
-              <div>${c.idTituloPromocao}</div>
-              <div class="label">Prêmio</div>
-              <div>${c.premio || ''}</div>
-            </div>
-          </div>
-          <div class="status-badge">Encerrado</div>
+          `;
 
-          <button class="btn-expand">Ver dezenas</button>
-          <div class="expand-section">
-            ${c.imagemPremio
-              ? `<img src="${c.imagemPremio}" class="result-image" />`
-              : ''}
-            <table class="dezenas-table"></table>
-          </div>
-        `;
+          const table = card.querySelector('.dezenas-table');
+          const tbody = document.createElement('tbody');
 
-        resultsEl.appendChild(card);
+          for (let i = 0; i < dezenas.length; i += 5) {
+            const row = document.createElement('tr');
+            dezenas.slice(i, i + 5).forEach(num => {
+              const td = document.createElement('td');
+              td.textContent = num.toString().padStart(2, '0');
+              row.appendChild(td);
+            });
+            tbody.appendChild(row);
+          }
 
-        // montar a tabela de dezenas
-        const expandSection = card.querySelector('.expand-section');
-        const table = expandSection.querySelector('.dezenas-table');
-
-        // cabeçalho da tabela: Chance e Título
-        const headerRow = document.createElement('tr');
-        const thChance = document.createElement('th');
-        thChance.textContent = `Chance (${c.chance || ''})`;
-        headerRow.appendChild(thChance);
-
-        const thTitulo = document.createElement('th');
-        thTitulo.setAttribute('colspan', '4');
-        thTitulo.textContent = `Nº do Título ${c.idTituloPromocao}`;
-        headerRow.appendChild(thTitulo);
-
-        table.appendChild(headerRow);
-
-        // quebra o array de dezenas em linhas de 5 colunas
-        const dezenas = c.dezenas || [];
-        for (let i = 0; i < dezenas.length; i += 5) {
-          const row = document.createElement('tr');
-          dezenas.slice(i, i + 5).forEach(num => {
-            const td = document.createElement('td');
-            td.textContent = num.toString().padStart(2, '0');
-            row.appendChild(td);
-          });
-          table.appendChild(row);
-        }
-
-        // evento de expandir/colapsar
-        const btnExpand = card.querySelector('.btn-expand');
-        btnExpand.addEventListener('click', () => {
-          const isOpen = expandSection.style.display === 'block';
-          expandSection.style.display = isOpen ? 'none' : 'block';
-          btnExpand.textContent = isOpen ? 'Ver dezenas' : 'Ocultar dezenas';
+          table.appendChild(tbody);
+          resultsEl.appendChild(card);
         });
       });
   });


### PR DESCRIPTION
## Summary
- revamp coupon results layout to show chance grid with banner
- style dozens table in 5-column grid
- remove margin on mobile

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687db19ff8408325a324aa5e1757a0f3