### PR TITLE
Fix dialog display and improve exit popup

### DIFF
--- a/public/js/checkout.js
+++ b/public/js/checkout.js
@@ -70,7 +70,7 @@ window.addEventListener('DOMContentLoaded', () => {
   });
 
   document.addEventListener('mouseleave', async () => {
-    if (step === 2) {
+    if (step === 1 || step === 2) {
       const out = await showDialog('Tem certeza que deseja abandonar a compra?', {
         cancel: true,
         okText: 'Sair'

--- a/public/js/dialog.js
+++ b/public/js/dialog.js
@@ -1,43 +1,59 @@
 (function(){
+  let activeDialog = null;
+
   window.showDialog = function(message, options = {}) {
     const { cancel = false, okText = 'OK', cancelText = 'Cancelar' } = options;
-    return new Promise(resolve => {
-      const overlay = document.createElement('div');
-      overlay.className = 'modal-overlay';
-      const modal = document.createElement('div');
-      modal.className = 'modal';
 
-      const p = document.createElement('p');
-      p.className = 'modal-message';
-      p.textContent = message;
-      modal.appendChild(p);
+    // If a dialog is already displayed return its promise
+    if (activeDialog) {
+      return activeDialog.promise;
+    }
 
-      const btnWrap = document.createElement('div');
-      btnWrap.className = 'modal-buttons';
-
-      if (cancel) {
-        const cancelBtn = document.createElement('button');
-        cancelBtn.className = 'secondary';
-        cancelBtn.textContent = cancelText;
-        cancelBtn.addEventListener('click', () => {
-          document.body.removeChild(overlay);
-          resolve(false);
-        });
-        btnWrap.appendChild(cancelBtn);
-      }
-
-      const okBtn = document.createElement('button');
-      okBtn.className = 'primary';
-      okBtn.textContent = okText;
-      okBtn.addEventListener('click', () => {
-        document.body.removeChild(overlay);
-        resolve(true);
-      });
-      btnWrap.appendChild(okBtn);
-
-      modal.appendChild(btnWrap);
-      overlay.appendChild(modal);
-      document.body.appendChild(overlay);
+    let resolveFn;
+    const promise = new Promise(resolve => {
+      resolveFn = resolve;
     });
+
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
+    const modal = document.createElement('div');
+    modal.className = 'modal';
+
+    const p = document.createElement('p');
+    p.className = 'modal-message';
+    p.textContent = message;
+    modal.appendChild(p);
+
+    const btnWrap = document.createElement('div');
+    btnWrap.className = 'modal-buttons';
+
+    if (cancel) {
+      const cancelBtn = document.createElement('button');
+      cancelBtn.className = 'secondary';
+      cancelBtn.textContent = cancelText;
+      cancelBtn.addEventListener('click', () => {
+        document.body.removeChild(overlay);
+        activeDialog = null;
+        resolveFn(false);
+      });
+      btnWrap.appendChild(cancelBtn);
+    }
+
+    const okBtn = document.createElement('button');
+    okBtn.className = 'primary';
+    okBtn.textContent = okText;
+    okBtn.addEventListener('click', () => {
+      document.body.removeChild(overlay);
+      activeDialog = null;
+      resolveFn(true);
+    });
+    btnWrap.appendChild(okBtn);
+
+    modal.appendChild(btnWrap);
+    overlay.appendChild(modal);
+    document.body.appendChild(overlay);
+
+    activeDialog = { overlay, promise };
+    return promise;
   };
 })();


### PR DESCRIPTION
## Summary
- avoid duplicate dialogs by keeping a single active popup
- trigger mouse-leave warning on both checkout steps

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687fd0c3dcc48325b845f066431fa3fa