### PR TITLE
Fix layout shifting by removing global transition

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -86,7 +86,7 @@
   box-sizing: border-box;
   margin: 0;
   padding: 0;
-  transition: all 0.1s ease-in-out;
+  /* Removed universal transition to avoid unwanted layout shifts */
 }
 
 html,


### PR DESCRIPTION
## Summary
- remove universal transition rule from the CSS reset

This prevents margins and paddings from animating when dialogs or page elements are toggled, keeping the layout stable.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687fd2c4a8f08325a4db63ceb85f8d6f