### PR TITLE
Add Basic auth password header

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,5 +40,6 @@ O projeto simula o fluxo de compra de títulos do HiperCap, permitindo gerar um 
 
 - `HIPERCAP_BASE_URL` e `HIPERCAP_KEY` – Acesso aos serviços de compra.
 - `HIPERCAP_CUSTOMER_ID` e `HIPERCAP_CUSTOMER_KEY` – Consulta de promoção.
-- `GATEWAY_URL` e `GATEWAY_KEY` – Integração com o Gateway IdeaMaker.
+- `GATEWAY_URL` e `GATEWAY_KEY` – Integração principal com o Gateway IdeaMaker.
+- `GATEWAY_KEY_2` – Senha utilizada na autenticação básica adicional do Gateway.
 

--- a/server.js
+++ b/server.js
@@ -27,10 +27,14 @@ const PROMO_HEADERS = {
   'Content-Type': 'application/json'
 };
 const GATEWAY_URL    = process.env.GATEWAY_URL || 'https://sandbox.paymentgateway.ideamaker.com.br/';
+// Prepara os headers utilizados nas chamadas ao Gateway.
+// "GATEWAY_KEY_2" representa a senha usada na aba Authorization do Postman
+// (usuário em branco). Para simular esse comportamento, enviamos dois
+// valores para o cabeçalho Authorization.
+const gateway2Auth = Buffer.from(':' + process.env.GATEWAY_KEY_2).toString('base64');
 const GATEWAY_HEADER = {
   'Content-Type': 'application/json',
-  'Authorization': `Basic ${process.env.GATEWAY_KEY}`,
-  'Authorization': `${process.env.GATEWAY_KEY_2}`
+  Authorization: [`Basic ${process.env.GATEWAY_KEY}`, `Basic ${gateway2Auth}`]
 };
 
 // dispara evento de pagamento para ambiente de testes


### PR DESCRIPTION
## Summary
- support second Basic Auth using `GATEWAY_KEY_2`
- document new auth variable

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6880f59407388325a43818a03150dc99