### PR TITLE
Add payment success step

### DIFF
--- a/public/checkout.html
+++ b/public/checkout.html
@@ -155,6 +155,11 @@
       </section>
     </div>
   </div>
+  <div class="success-panel" id="successPanel" style="display:none">
+    <h2>Pagamento aprovado!</h2>
+    <p>Agora você já está concorrendo.</p>
+    <a id="goConsulta" href="/consulta" class="submit-btn">Ver meus títulos</a>
+  </div>
 
   <!-- NAVEGAÇÃO INFERIOR (apenas mobile) -->
   <nav class="bottom-nav">

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -8,6 +8,7 @@
   /* Support Colors */
   --color-support-yellow-500: #ffcc00;
   --color-support-red-700: #c00811;
+  --support-green-700: #21a366;
 
   /* Neutral */
   --color-neutral-black: #191c1f;
@@ -1415,4 +1416,35 @@ img {
 .modal-buttons .secondary {
   background: var(--color-neutral-200);
   color: var(--color-neutral-black);
+}
+/* STEP 3: payment success */
+.checkout-grid.step-3 .purchase-panel,
+.checkout-grid.step-3 .qr-panel,
+.checkout-grid.step-3 #qrCountdown {
+  display: none !important;
+}
+.checkout-grid.step-3 .success-panel {
+  display: flex !important;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem;
+  gap: 1rem;
+  text-align: center;
+}
+.checkout-grid.step-3 .success-panel h2 {
+  color: var(--support-green-700);
+  font-family: var(--font-family-heading);
+}
+.checkout-grid.step-3 .success-panel .submit-btn {
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 62.5rem;
+  background: var(--gradient-1);
+  color: var(--color-neutral-white);
+  font-weight: bold;
+  text-decoration: none;
+}
+.checkout-grid.step-3 .progress {
+  width: 100% !important;
+  background: var(--support-green-700);
 }

--- a/public/js/checkout.js
+++ b/public/js/checkout.js
@@ -12,6 +12,8 @@ let expireTimer;
 let expireCountdownStarted = false;
 const gridEl     = document.querySelector('.checkout-grid');
 const stepCount  = document.querySelector('.step-count');
+const successPanel = document.getElementById("successPanel");
+const goConsulta = document.getElementById("goConsulta");
 const qrCountdown = document.getElementById('qrCountdown');
 
 function resetCheckout() {
@@ -21,6 +23,8 @@ function resetCheckout() {
   document.getElementById('qrPlaceholder').style.display = 'block';
   if (qrCountdown) qrCountdown.style.display = 'none';
   gridEl.classList.remove('step-2');
+  gridEl.classList.remove("step-3");
+  if (successPanel) successPanel.style.display = "none";
   if (stepCount) stepCount.textContent = '1 de 2';
   if (pollTimer) clearTimeout(pollTimer);
   if (expireTimer) clearInterval(expireTimer);
@@ -150,6 +154,7 @@ function showQR(data) {
   document.getElementById('qrPlaceholder').style.display = 'none';
   document.getElementById('qrSection').style.display     = 'block';
   document.getElementById('qrImg').src                   = data.qrImage;
+  if (successPanel) successPanel.style.display = "none";
   document.getElementById('copyCode').textContent        = data.qrCode;
   document.getElementById('paymentStatus').textContent   = data.status;
   document.querySelector('.payment-instructions').style.display = 'none';
@@ -346,4 +351,12 @@ async function finalizePurchase() {
     console.error(data.error || 'Erro ao registrar atendimento');
   }
   localStorage.removeItem('currentPayment');
+  goConsulta.href = `/consulta?cpf=${buyerCPF.replace(/\D/g, "")}`;
+  document.querySelector(".purchase-panel").style.display = "none";
+  document.querySelector(".qr-panel").style.display = "none";
+  if (qrCountdown) qrCountdown.style.display = "none";
+  if (successPanel) successPanel.style.display = "flex";
+  gridEl.classList.add("step-3");
+  if (stepCount) stepCount.textContent = "2 de 2";
+  step = 3;
 }

--- a/public/js/consulta.js
+++ b/public/js/consulta.js
@@ -231,3 +231,14 @@ function displayResults(data) {
   });
 }
 
+
+const params = new URLSearchParams(window.location.search);
+const cpfQuery = params.get('cpf');
+if (cpfQuery) {
+  currentCpf = cpfQuery.replace(/\D/g, '');
+  const input = document.getElementById('cpf');
+  if (input) input.value = cpfQuery.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4');
+  selectedProducts = ['hipercapbrasil'];
+  currentPage = 1;
+  fetchCoupons();
+}


### PR DESCRIPTION
## Summary
- add missing green color variable and styles for success step
- show success panel in checkout after pix payment is paid
- redirect to consulta with CPF
- auto-fill consulta page when arriving with CPF query

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68810594e4d08325b256746d3dfd2e2d