### PR TITLE
Adjust checkout registration flow

### DIFF
--- a/server.js
+++ b/server.js
@@ -292,6 +292,22 @@ app.post('/api/attend', async (req, res) => {
   }
 });
 
+// 7) Confirma atendimento quando pagamento aprovado
+app.post('/api/confirm', async (req, res) => {
+  const { protocolo } = req.body;
+  try {
+    const conf = await axios.post(
+      `${BASE_URL}/servicos/vendas/titulos/confirmaAtendimento`,
+      { protocolo, aprovado: true },
+      { headers: PROMO_HEADERS }
+    );
+    return res.json(conf.data);
+  } catch (err) {
+    console.error(err.response?.data || err.message);
+    return res.status(500).json({ error: 'Falha ao confirmar atendimento.' });
+  }
+});
+
 // ============================
 //  PÁGINAS POR SUBDOMÍNIO
 // ============================


### PR DESCRIPTION
## Summary
- register atendimento before calling the payment gateway
- send protocolo confirmation when payment is approved

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6881383586b48325bf9dcc5e65c7af71