### PR TITLE
Enhance consulta navigation and QR display

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1535,6 +1535,15 @@ img {
   margin-top: 0.5rem;
   cursor: pointer;
 }
+.qr-btn {
+  width: 100%;
+  background: var(--color-brand-primary-600);
+  color: var(--color-neutral-white);
+  border: none;
+  padding: 0.5rem;
+  margin: 0.5rem 0;
+  cursor: pointer;
+}
 .sorteio-btn.open {
   background: var(--color-brand-primary-700);
 }


### PR DESCRIPTION
## Summary
- display only three coupons per page
- show QR codes in a modal when user clicks a button
- toggle all sorteios with a single button
- stop auto-loading results when CPF is preset and show product selection instead

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68814d160cf4832596f592e7e486f24c