### PR TITLE
Add promotion results page

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1877,3 +1877,50 @@ button,
 .back-btn {
   transition: padding 0.15s ease, margin 0.15s ease;
 }
+/* ===== Resultados ===== */
+.results-wrapper {
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+.result-select {
+  width: 100%;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+}
+.accordion-item {
+  border-bottom: 1px solid #eee;
+  margin-bottom: 0.5rem;
+}
+.accordion-button {
+  width: 100%;
+  text-align: left;
+  background: #f8f8f8;
+  border: none;
+  padding: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  position: relative;
+}
+.accordion-button::after {
+  content: '+';
+  position: absolute;
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+}
+.accordion-button.active::after {
+  content: '-';
+}
+.accordion-content {
+  display: none;
+  padding: 0.75rem;
+  background: #fff;
+}
+.winner-list {
+  list-style: none;
+  padding-left: 1rem;
+}
+.winner-list li {
+  margin-bottom: 0.25rem;
+}

--- a/public/js/results.js
+++ b/public/js/results.js
@@ -1,0 +1,81 @@
+// public/js/results.js
+
+function parseDate(str) {
+  if (typeof str === 'string' && str.includes('/')) {
+    const [d, m, rest] = str.split('/');
+    const [y, time] = rest.split(' ');
+    return new Date(`${y}-${m}-${d}T${time || '00:00'}`);
+  }
+  return new Date(str);
+}
+
+async function loadPromotions() {
+  const select = document.getElementById('promoSelect');
+  const resp = await fetch('/api/promo-results');
+  const data = await resp.json();
+  const list = Array.isArray(data.values) ? data.values : [];
+  list.sort((a, b) => parseDate(b.dataSorteioPrincipal) - parseDate(a.dataSorteioPrincipal));
+  list.forEach(p => {
+    const opt = document.createElement('option');
+    const [date] = (p.dataSorteioPrincipal || '').split(' ');
+    opt.value = p.id;
+    opt.textContent = `${date} - ${p.titulo}`;
+    select.appendChild(opt);
+  });
+  if (list.length) {
+    select.value = list[0].id;
+    loadResult(list[0].id);
+  }
+}
+
+async function loadResult(id) {
+  const container = document.getElementById('resultsContainer');
+  container.innerHTML = 'Carregando...';
+  const resp = await fetch(`/api/promo-results/${id}`);
+  const data = await resp.json();
+  container.innerHTML = '';
+  if (!Array.isArray(data.sorteios)) return;
+  data.sorteios.sort((a, b) => a.ordem - b.ordem);
+  data.sorteios.forEach(s => {
+    const item = document.createElement('div');
+    item.className = 'accordion-item';
+
+    const btn = document.createElement('button');
+    btn.className = 'accordion-button';
+    btn.textContent = s.descricao || `Sorteio ${s.ordem}`;
+    item.appendChild(btn);
+
+    const content = document.createElement('div');
+    content.className = 'accordion-content';
+
+    if (Array.isArray(s.ganhadores)) {
+      const ul = document.createElement('ul');
+      ul.className = 'winner-list';
+      s.ganhadores.forEach(g => {
+        const li = document.createElement('li');
+        const city = g.cidade ? ` - ${g.cidade}` : '';
+        li.textContent = `${g.nome}${city} - Título ${g.titulo}`;
+        ul.appendChild(li);
+      });
+      content.appendChild(ul);
+    }
+
+    item.appendChild(content);
+    btn.addEventListener('click', () => {
+      btn.classList.toggle('active');
+      if (content.style.display === 'block') {
+        content.style.display = 'none';
+      } else {
+        content.style.display = 'block';
+      }
+    });
+
+    container.appendChild(item);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const select = document.getElementById('promoSelect');
+  select.addEventListener('change', () => loadResult(select.value));
+  loadPromotions();
+});

--- a/public/results.html
+++ b/public/results.html
@@ -1,27 +1,28 @@
-<!-- Página de resultados -->
-<!doctype html>
+<!DOCTYPE html>
 <html lang="pt-BR">
-  <head>
-    <meta charset="utf-8" />
-    <title>Resultados – HiperCap</title>
-    <link rel="stylesheet" href="/css/style.css" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
-      rel="stylesheet"
-    />
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
-      integrity="sha384-PPIZEGYM1v8zp5Py7UjFb79S58UeqCL9pYVnVPURKEqvioPROaVAJKKLzvH2rDnI"
-      crossorigin="anonymous"
-      referrerpolicy="no-referrer"
-    />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-  </head>
-  <body>
-    <h1>Resultados</h1>
-    <p>Esta página ainda será desenvolvida.</p>
-  </body>
+<head>
+  <meta charset="utf-8">
+  <title>Resultados – HiperCap</title>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha384-PPIZEGYM1v8zp5Py7UjFb79S58UeqCL9pYVnVPURKEqvioPROaVAJKKLzvH2rDnI" crossorigin="anonymous" referrerpolicy="no-referrer">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body class="page">
+  <header class="header">
+    <button class="btn-back" onclick="history.back()"><i class="fa fa-arrow-left"></i></button>
+    <h1 class="header-title">Resultados</h1>
+  </header>
+
+  <main class="results-wrapper">
+    <label for="promoSelect">Selecione a promoção:</label>
+    <select id="promoSelect" class="result-select"></select>
+
+    <div id="resultsContainer" class="results-container"></div>
+  </main>
+
+  <script src="/js/results.js"></script>
+</body>
 </html>

--- a/server.js
+++ b/server.js
@@ -261,6 +261,36 @@ app.get('/api/promotion', async (req, res) => {
   }
 });
 
+// 5.1) Lista de promoções finalizadas
+app.get('/api/promo-results', async (req, res) => {
+  try {
+    const resp = await axios.get(
+      'https://apiv3.sp.apcap.com.br/servicos/resultado/promocao/vidacap',
+      { headers: PROMO_HEADERS }
+    );
+    return res.json(resp.data);
+  } catch (err) {
+    console.error(err.response?.data || err.message);
+    return res.status(500).json({ error: 'Falha ao obter promoções.' });
+  }
+});
+
+// 5.2) Detalhes de resultado da promoção por ID
+app.get('/api/promo-results/:id', async (req, res) => {
+  const { id } = req.params;
+  try {
+    const resp = await axios.get(
+      `https://apiv3.sp.apcap.com.br/servicos/resultado/promocao/${id}`,
+      { headers: PROMO_HEADERS }
+    );
+    return res.json(resp.data);
+  } catch (err) {
+    console.error(err.response?.data || err.message);
+    return res.status(500).json({ error: 'Falha ao obter resultado.' });
+  }
+});
+
+
 // 6) Registra atendimento (após pagamento aprovado)
 app.post('/api/attend', async (req, res) => {
   const { cpf, phone, quantity } = req.body;


### PR DESCRIPTION
## Summary
- implement API routes to fetch promotion results
- add results page with dropdown and accordion UI
- style accordions and results section
- add client-side script to load and display results

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6882fc5d9a748325bf8f8e32b4d9860c