### PR TITLE
Load main banner from promotion

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -27,7 +27,7 @@
 
   <!-- BANNER PRINCIPAL (sempre 100% largura) -->
   <section class="main-banner">
-    <img src="img/banner-premio.png" alt="Banner HiperCap Brasil" class="banner-img">
+    <img id="promoBanner" src="img/banner-premio.png" alt="Banner HiperCap Brasil" class="banner-img">
   </section>
 
   <!-- CHAMADA AZUL -->
@@ -214,5 +214,6 @@
       }
     });
   </script>
+  <script src="/js/index.js"></script>
 </body>
 </html>

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1,0 +1,11 @@
+window.addEventListener('DOMContentLoaded', () => {
+  fetch('/api/promotion')
+    .then(r => r.json())
+    .then(promo => {
+      if (promo && promo.banner) {
+        const img = document.getElementById('promoBanner');
+        if (img) img.src = promo.banner;
+      }
+    })
+    .catch(err => console.error('Promo fetch error', err));
+});


### PR DESCRIPTION
## Summary
- fetch promotion info on index page
- display promo banner in main banner section

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68830a9d9c288325bba8e52d04399682