### PR TITLE
Stop PIX countdown after payment

### DIFF
--- a/public/js/checkout.js
+++ b/public/js/checkout.js
@@ -343,6 +343,9 @@ async function loadPayment(id) {
 
 // 4) Confirma atendimento apos pagamento
 async function finalizePurchase() {
+  if (pollTimer) clearTimeout(pollTimer);
+  if (expireTimer) clearInterval(expireTimer);
+  expireCountdownStarted = false;
   if (currentProtocol) {
     const resp = await fetch('/api/confirm', {
       method: 'POST',


### PR DESCRIPTION
## Summary
- clear timers once payment is complete so countdown stops

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68839414eb248325a4297bf73752314a