### PR TITLE
Fix checkout countdown

### DIFF
--- a/public/js/checkout.js
+++ b/public/js/checkout.js
@@ -252,8 +252,13 @@ function setupPromotion(promo) {
   });
 
   // — Countdown to draw —
-  if (promo.dataSorteioPrincipal) {
-    startCountdown(parseDate(promo.dataSorteioPrincipal));
+  const sorteioDate =
+    promo.dataSorteioPrincipal ||
+    promo.promocao?.dataSorteioPrincipal ||
+    (promo.promocoes && promo.promocoes[0]?.dataSorteioPrincipal);
+
+  if (sorteioDate) {
+    startCountdown(parseDate(sorteioDate));
   }
 }
 // 2) Envia o formulário: chama /api/purchase e mostra o QR


### PR DESCRIPTION
## Summary
- make the checkout timer look for multiple `dataSorteioPrincipal` fields

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6883ba4c55808325af093044686d3117