### PR TITLE
Fix countdown timer initialization error

### DIFF
--- a/public/js/checkout.js
+++ b/public/js/checkout.js
@@ -133,6 +133,7 @@ function startCountdown(target) {
     m: document.getElementById('minutes'),
     s: document.getElementById('seconds'),
   };
+  let timer;
   function tick() {
     const diff = target - new Date();
     if (diff <= 0) return clearInterval(timer);
@@ -142,8 +143,8 @@ function startCountdown(target) {
     el.m.textContent = String(Math.floor((t % 3600) / 60)).padStart(2, '0');
     el.s.textContent = String(t % 60).padStart(2, '0');
   }
+  timer = setInterval(tick, 1000);
   tick();
-  const timer = setInterval(tick, 1000);
 }
 
 function startExpireCountdown(target) {


### PR DESCRIPTION
## Summary
- prevent `timer` ReferenceError in `startCountdown`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6883bc4506548325a94240166c8c433d