### PR TITLE
Add page indicator when switching coupon pages

### DIFF
--- a/public/consulta.html
+++ b/public/consulta.html
@@ -75,6 +75,7 @@
         <span id="pageNum">1</span>
         <button type="button" id="nextPage" class="pagination-btn "><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="chevron-right" class="svg-inline--fa fa-chevron-right " role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="" d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"></path></svg></button>
       </div>
+      <div id="pageIndicator" class="page-indicator" style="display:none;"></div>
     </section>
 
     

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1914,3 +1914,24 @@ button,
 .back-btn {
   transition: padding 0.15s ease, margin 0.15s ease;
 }
+
+/* Indicador de página para a consulta */
+.page-indicator {
+  position: fixed;
+  bottom: 5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  font-weight: 700;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 1000;
+}
+
+.page-indicator.show {
+  opacity: 1;
+}

--- a/public/js/consulta.js
+++ b/public/js/consulta.js
@@ -21,6 +21,7 @@ const resultsSection = document.getElementById('resultsSection');
 const errorMsgEl     = document.getElementById('errorMsg');
 const pageNumEl      = document.getElementById('pageNum');
 const resultsEl      = document.getElementById('results');
+const pageIndicatorEl = document.getElementById('pageIndicator');
 const btnBack        = document.getElementById('btnBack');
 const productList    = stepProducts.querySelector('.product-list');
 const productMsg     = stepProducts.querySelector('p');
@@ -108,15 +109,31 @@ cpfForm.addEventListener('submit', async e => {
 
 // Passo 2: seleção de produto agora acontece ao clicar no item
 
+function showPageIndicator(page) {
+  if (!pageIndicatorEl) return;
+  pageIndicatorEl.textContent = `Página ${page}`;
+  pageIndicatorEl.style.display = 'block';
+  pageIndicatorEl.classList.add('show');
+  clearTimeout(showPageIndicator._t);
+  showPageIndicator._t = setTimeout(() => {
+    pageIndicatorEl.classList.remove('show');
+    pageIndicatorEl.style.display = 'none';
+  }, 1000);
+}
+
 // Navegação de páginas
 document.getElementById('prevPage').addEventListener('click', () => {
   if (currentPage > 1) {
     currentPage--;
+    pageNumEl.textContent = currentPage;
+    showPageIndicator(currentPage);
     fetchCoupons();
   }
 });
 document.getElementById('nextPage').addEventListener('click', () => {
   currentPage++;
+  pageNumEl.textContent = currentPage;
+  showPageIndicator(currentPage);
   fetchCoupons();
 });
 


### PR DESCRIPTION
## Summary
- show current page in an indicator when navigating coupon pages
- update HTML markup for indicator
- style page indicator

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6887e3d7ebb88325bad90c1ee6f42d05