### PR TITLE
Disable navigation past last page

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1884,6 +1884,10 @@ img {
   cursor: not-allowed;
   color: var(--color-neutral-300);
 }
+
+.pagination-btn:disabled svg {
+  fill: rgba(129, 129, 129, 0.3);
+}
 .success-image {
   width: 100%;
   max-width: 300px;


### PR DESCRIPTION
## Summary
- prevent navigation arrows in consulta when no further pages exist
- update pagination handlers to check disabled state
- prefetch the next page and disable arrow if results unavailable
- grey out pagination arrows when disabled

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688a2b31bf5c8325bf2d6103483e3be4