### PR TITLE
feat: redirect local paths to production subdomains

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ O projeto simula o fluxo de compra de títulos do HiperCap, permitindo gerar um 
    node server.js
    ```
 3. Para desenvolvimento local, acesse `http://localhost:3000` e navegue entre `/checkout`, `/consulta` e `/resultados`.
-   Em produção, configure subdomínios apontando para o mesmo servidor:
+   Em produção, essas rotas redirecionam automaticamente para os subdomínios
+   correspondentes. Configure subdomínios apontando para o mesmo servidor:
    - `compra.seudominio.com` → `checkout.html`
    - `consulta.seudominio.com` → `consulta.html`
    - `resultados.seudominio.com` → `results.html`

--- a/server.js
+++ b/server.js
@@ -328,9 +328,19 @@ app.use((req, res, next) => {
 // ============================
 //  ROTAS LOCAIS (DESENVOLVIMENTO)
 // ============================
-app.get(['/checkout', '/consulta', '/results'], (req, res) => {
-  const page = req.path.slice(1) + '.html';
-  res.sendFile(path.join(__dirname, 'public', page));
+const localRoutes = {
+  '/checkout':   { file: 'checkout.html',  sub: 'compra' },
+  '/consulta':   { file: 'consulta.html',  sub: 'consulta' },
+  '/results':    { file: 'results.html',   sub: 'resultados' },
+  '/resultados': { file: 'results.html',   sub: 'resultados' }
+};
+
+app.get(Object.keys(localRoutes), (req, res) => {
+  const { file, sub } = localRoutes[req.path];
+  if (isDev) {
+    return res.sendFile(path.join(__dirname, 'public', file));
+  }
+  return res.redirect(`https://${sub}.${req.hostname}`);
 });
 
 app.listen(PORT, HOST, () => {


### PR DESCRIPTION
## Summary
- redirect checkout, consulta and results paths to appropriate subdomains in production
- document automatic redirect behavior in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68958227e52083258af8df3837729369