### PR TITLE
Disable checkout quantity controls at limits

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -308,6 +308,12 @@ img {
   width: 1em;
   height: 1em;
 }
+.qty-btn:disabled {
+  background: var(--color-neutral-200);
+  color: var(--color-neutral-500);
+  fill: var(--color-neutral-500);
+  cursor: not-allowed;
+}
 #quantity {
   width: 2.5rem;
   text-align: center;

--- a/public/js/checkout.js
+++ b/public/js/checkout.js
@@ -249,20 +249,24 @@ function setupPromotion(promo) {
   const qtyInput     = document.getElementById('quantityInput');
   const qtyDisplay   = document.getElementById('quantity');
   const totalDisplay = document.getElementById('totalAmount');
+  const incBtn       = document.getElementById('increase');
+  const decBtn       = document.getElementById('decrease');
 
   function update() {
     qtyInput.value            = qty;
     qtyDisplay.textContent    = qty;
     totalDisplay.textContent  = (qty * price).toFixed(2).replace('.', ',');
     currentQty                = qty;
+    incBtn.disabled = qty >= max;
+    decBtn.disabled = qty <= min;
   }
 
   update();
 
-  document.getElementById('increase').addEventListener('click', () => {
+  incBtn.addEventListener('click', () => {
     if (qty < max) { qty++; update(); }
   });
-  document.getElementById('decrease').addEventListener('click', () => {
+  decBtn.addEventListener('click', () => {
     if (qty > min) { qty--; update(); }
   });
 


### PR DESCRIPTION
## Summary
- Grey out and disable quantity increment/decrement buttons when hitting min/max
- Apply disabled styling for qty buttons in checkout

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689b8152df48832584262c52a72f8ac6