### PR TITLE
Add webhook route for Pix payment confirmation

### DIFF
--- a/public/js/checkout.js
+++ b/public/js/checkout.js
@@ -348,7 +348,7 @@ document.getElementById('purchaseForm').addEventListener('submit', async e => {
   const resp   = await fetch('/api/purchase', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ amount, cpf: buyerCPF })
+    body: JSON.stringify({ amount, cpf: buyerCPF, protocolo: currentProtocol })
   });
   const data = await resp.json();
   if (!resp.ok) {


### PR DESCRIPTION
## Summary
- map payment IDs to atendimento protocols when creating Pix payments
- expose `/webhook/idea/gateway` to receive Pix webhook and confirm atendimento
- send protocolo from checkout when requesting a payment

## Testing
- `node --check server.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689f82b34de883258a03fff362028704