### PR TITLE
Use sorteio API for homepage banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ O projeto simula o fluxo de compra de títulos do HiperCap, permitindo gerar um 
 
 - `HIPERCAP_BASE_URL` e `HIPERCAP_KEY` – Acesso aos serviços de compra.
 - `HIPERCAP_CUSTOMER_ID` e `HIPERCAP_CUSTOMER_KEY` – Consulta de promoção.
+- `SORTEIO_ACCESS_ID` e `SORTEIO_ACCESS_KEY` – Consulta dos dados de sorteio para exibir o banner.
 - `GATEWAY_URL` e `GATEWAY_KEY` – Integração principal com o Gateway IdeaMaker.
 - `GATEWAY_KEY_2` – Senha utilizada na autenticação básica adicional do Gateway.
 - `TURNSTILE_SITE_KEY` e `TURNSTILE_SECRET_KEY` – Chaves do Cloudflare Turnstile usadas para validar o captcha na consulta de CPF.

--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,7 @@
 
   <link rel="stylesheet" href="css/index_style.css">
 </head>
-<body>
+<body style="display:none;">
   <!-- HEADER -->
   <header class="header">
     <div class="header-container">

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1,11 +1,19 @@
 window.addEventListener('DOMContentLoaded', () => {
-  fetch('/api/promotion')
+  const body = document.body;
+  const img = document.getElementById('promoBanner');
+  const show = () => { body.style.display = 'block'; };
+
+  fetch('/api/sorteio')
     .then(r => r.json())
-    .then(promo => {
-      if (promo && promo.banner) {
-        const img = document.getElementById('promoBanner');
-        if (img) img.src = promo.banner;
+    .then(data => {
+      const banner = data?.banner || data?.imagem || data?.urlImagem;
+      if (banner && img) {
+        img.onload = show;
+        img.onerror = show;
+        img.src = banner;
+      } else {
+        show();
       }
     })
-    .catch(err => console.error('Promo fetch error', err));
+    .catch(err => { console.error('Sorteio fetch error', err); show(); });
 });

--- a/server.js
+++ b/server.js
@@ -23,6 +23,11 @@ const PROMO_HEADERS = {
   'Content-Type': 'application/json'
 };
 
+const SORTEIO_HEADERS = {
+  accessid: process.env.SORTEIO_ACCESS_ID,
+  accesskey: process.env.SORTEIO_ACCESS_KEY
+};
+
 const GATEWAY_URL = process.env.GATEWAY_URL || 'https://sandbox.paymentgateway.ideamaker.com.br/';
 const gateway2Auth = Buffer.from(':' + process.env.GATEWAY_KEY).toString('base64');
 const GATEWAY_HEADER = { 'Content-Type': 'application/json', Authorization: [`Basic ${gateway2Auth}`] };
@@ -340,6 +345,20 @@ app.get('/api/promotion', async (req, res) => {
   } catch (err) {
     req.log.error({ msg: 'Falha ao obter promoção', error: err.response?.data || err.message });
     return res.status(500).json({ error: 'Falha ao obter promoção.' });
+  }
+});
+
+app.get('/api/sorteio', async (req, res) => {
+  try {
+    const resp = await axios.get(
+      'https://apil4-54ugmdhbvq-ue.a.run.app/sorteios/dados-sorteio',
+      { params: { idPraca: 30 }, headers: SORTEIO_HEADERS }
+    );
+    req.log.info({ msg: 'Dados de sorteio obtidos' });
+    return res.json(resp.data);
+  } catch (err) {
+    req.log.error({ msg: 'Falha ao obter dados de sorteio', error: err.response?.data || err.message });
+    return res.status(500).json({ error: 'Falha ao obter dados de sorteio.' });
   }
 });
 


### PR DESCRIPTION
## Summary
- load homepage banner from new sorteio endpoint
- delay page render until banner image finishes loading
- document env vars for sorteio access

## Testing
- `node --check server.js`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a159aa0be483259f74d8532d914efa