### PR TITLE
Trigger conversion event after checkout confirmation

### DIFF
--- a/public/js/checkout.js
+++ b/public/js/checkout.js
@@ -429,6 +429,11 @@ async function finalizePurchase() {
       console.error(data.error || 'Erro ao confirmar atendimento');
     }
   }
+  if (typeof gtag === 'function') {
+    gtag('event', 'conversion', {
+      'send_to': 'AW-16607386911/_9WSCO2n-YQbEJ-6gu89'
+    });
+  }
   localStorage.removeItem('currentPayment');
   goConsulta.href = `/consulta?cpf=${buyerCPF.replace(/\D/g, "")}`;
   document.querySelector(".purchase-panel").style.display = "none";


### PR DESCRIPTION
## Summary
- fire Google Ads conversion when checkout completes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af49fd783c8325b5cbca894ac76706